### PR TITLE
Add marimoPath configuration option and use it in convertNotebook

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,6 +209,11 @@
           "type": "string",
           "default": "",
           "description": "Path to python executable"
+        },
+        "marimo.marimoPath": {
+          "type": "string",
+          "default": "marimo",
+          "description": "Path to marimo executable"
         }
       }
     }

--- a/src/convert/convert.ts
+++ b/src/convert/convert.ts
@@ -5,11 +5,11 @@ import { Uri, window, workspace } from "vscode";
 import { logger } from "../logger";
 import { printError } from "../utils/errors";
 
-export async function convertNotebook(filePath: string) {
+export async function convertNotebook(filePath: string, marimoPath: string) {
   try {
     // convert
     const directory = path.dirname(filePath);
-    const response = execSync(`marimo convert '${filePath}'`);
+    const response = execSync(`${marimoPath} convert '${filePath}'`);
     const appCode = response.toString();
 
     try {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import { commands, env, ExtensionContext, Uri, window } from "vscode";
+import { commands, env, ExtensionContext, Uri, window, workspace } from "vscode";
 import { start, stop } from "./launcher/start";
 import { updateStatusBar } from "./launcher/status-bar";
 import { showCommands } from "./launcher/show-commands";
@@ -78,8 +78,12 @@ export async function activate(extension: ExtensionContext) {
       window.showErrorMessage("Not a notebook file");
       return;
     }
-
-    await convertNotebook(filePath);
+    const marimoPath = workspace.getConfiguration("marimo").get("marimoPath") as string;
+    if (!marimoPath) {
+      window.showErrorMessage("Marimo path is not set");
+      return;
+    }
+    await convertNotebook(filePath, marimoPath);
   });
 
   window.onDidCloseTerminal((error) => {


### PR DESCRIPTION
Add 'marimoPath' configuration option and integrate it into the 'convertNotebook' function. This update addresses an issue where '/bin/sh' fails to recognize 'marimo' installed within a virtual environment, such as Conda or Mamba.