### PR TITLE
Update Debugging Settings in VS Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "type": "extensionHost",
       "request": "launch",
       "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
-      "outFiles": ["${workspaceFolder}/out/**/*.js"],
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
       "preLaunchTask": "${defaultBuildTask}"
     },
     {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
       "request": "launch",
       "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
       "outFiles": ["${workspaceFolder}/dist/**/*.js"],
-      "preLaunchTask": "${defaultBuildTask}"
+      "preLaunchTask": "npm: build"
     },
     {
       "name": "Extension Tests",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "build",
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"problemMatcher": [],
+			"label": "npm: build",
+			"detail": "tsup src/extension.ts --external=vscode"
+		}
+	]
+}


### PR DESCRIPTION
When working on #44, I noticed that setting Breakpoints did not work for me.

After some checks, I noticed, that the stated path for ``outFiles`` does not point to the standard folder for the sourcemap files tsup is writing to.

Additionally, I also added a explicit build task, just because I prefer it to using an automatic default build task, and that avoids the prompt asking for build options.

I'm not sure how the tests work, so I didn't change those settings, but there are no outfiles placed on the path stated in the ``launch.json``, so this at least feels weird...