### PR TITLE
feat: add support for --watch flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ You can configure the extension using the following settings:
 - `marimo.browserType`: Browser to open marimo app (`system` or `embedded`, default: `embedded`)
 - `marimo.port`: Default port for marimo server (default: `2818`)
 - `marimo.sandbox`: Always start marimo in a sandbox, e.g. `marimo edit --sandbox` (default: `false`). Requires [`uv`](https://docs.astral.sh/uv/) to be installed.
+- `marimo.watch`: Always start marimo with the `--watch` flag (default: `true`).
 - `marimo.host`: Hostname for marimo server (default: `localhost`)
 - `marimo.https`: Enable HTTPS for marimo server (default: `false`)
 - `marimo.enableToken`: Enable token authentication (default: `false`)

--- a/package.json
+++ b/package.json
@@ -336,6 +336,11 @@
           "default": false,
           "description": "Whether to always start marimo in a sandbox. Requires `uv` to be installed."
         },
+        "marimo.watch": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to always start marimo with the --watch flag."
+        },
         "marimo.https": {
           "type": "boolean",
           "default": false,

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,7 @@ export interface Config {
   readonly tokenPassword: string | undefined;
   readonly https: boolean;
   readonly sandbox: boolean;
+  readonly watch: boolean;
 }
 
 /**
@@ -130,6 +131,14 @@ export const Config = {
    */
   get sandbox(): boolean {
     return getConfig("sandbox", false);
+  },
+
+  /**
+   * Whether to always start marimo with the --watch flag.
+   * @default true
+   */
+  get watch(): boolean {
+    return getConfig("watch", true);
   },
 };
 

--- a/src/services/server-manager.ts
+++ b/src/services/server-manager.ts
@@ -283,6 +283,7 @@ export class ServerManager implements IServerManager {
       .enableToken(this.config.enableToken)
       .tokenPassword(this.config.tokenPassword)
       .sandbox(this.config.sandbox)
+      .watch(this.config.watch)
       .build();
   }
 

--- a/src/utils/__tests__/cmd.test.ts
+++ b/src/utils/__tests__/cmd.test.ts
@@ -20,7 +20,7 @@ describe("MarimoCmdBuilder", () => {
       .tokenPassword("")
       .build();
     expect(cmd).toMatchInlineSnapshot(
-      `"marimo --yes edit path/to/file --host=localhost --port=2718 --headless --no-token --watch"`,
+      `"marimo --yes edit path/to/file --host=localhost --port=2718 --headless --no-token"`,
     );
   });
 
@@ -36,7 +36,7 @@ describe("MarimoCmdBuilder", () => {
       .tokenPassword("secret")
       .build();
     expect(cmd).toMatchInlineSnapshot(
-      `"marimo --yes -d edit path/to/file --host=localhost --port=2718 --headless --token-password=secret --watch"`,
+      `"marimo --yes -d edit path/to/file --host=localhost --port=2718 --headless --token-password=secret"`,
     );
   });
 
@@ -52,7 +52,7 @@ describe("MarimoCmdBuilder", () => {
       .tokenPassword("")
       .build();
     expect(cmd).toMatchInlineSnapshot(
-      `"marimo --yes run path/to/file --host=localhost --port=2718 --headless --no-token --watch"`,
+      `"marimo --yes run path/to/file --host=localhost --port=2718 --headless --no-token"`,
     );
   });
 
@@ -69,7 +69,7 @@ describe("MarimoCmdBuilder", () => {
       .build();
 
     expect(b).toMatchInlineSnapshot(
-      `"marimo --yes edit "path/to/some file" --host=localhost --port=2718 --headless --no-token --watch"`,
+      `"marimo --yes edit "path/to/some file" --host=localhost --port=2718 --headless --no-token"`,
     );
   });
 
@@ -86,7 +86,7 @@ describe("MarimoCmdBuilder", () => {
       .build();
 
     expect(b).toMatchInlineSnapshot(
-      `"marimo --yes edit path/to/file --host=0.0.0.0 --port=2718 --headless --no-token --watch"`,
+      `"marimo --yes edit path/to/file --host=0.0.0.0 --port=2718 --headless --no-token"`,
     );
   });
 
@@ -102,7 +102,7 @@ describe("MarimoCmdBuilder", () => {
       .sandbox(true)
       .build();
     expect(cmd).toMatchInlineSnapshot(
-      `"marimo --yes edit path/to/file --host=localhost --port=2718 --headless --no-token --sandbox --watch"`,
+      `"marimo --yes edit path/to/file --host=localhost --port=2718 --headless --no-token --sandbox"`,
     );
   });
 
@@ -119,22 +119,6 @@ describe("MarimoCmdBuilder", () => {
       .build();
     expect(cmd).toMatchInlineSnapshot(
       `"marimo --yes edit path/to/file --host=localhost --port=2718 --headless --no-token --watch"`,
-    );
-  });
-
-  it("should support disabling watch mode", () => {
-    const cmd = new MarimoCmdBuilder()
-      .debug(false)
-      .mode("edit")
-      .fileOrDir("path/to/file")
-      .host("localhost")
-      .port(2718)
-      .headless(true)
-      .enableToken(false)
-      .watch(false)
-      .build();
-    expect(cmd).toMatchInlineSnapshot(
-      `"marimo --yes edit path/to/file --host=localhost --port=2718 --headless --no-token"`,
     );
   });
 });

--- a/src/utils/__tests__/cmd.test.ts
+++ b/src/utils/__tests__/cmd.test.ts
@@ -20,7 +20,7 @@ describe("MarimoCmdBuilder", () => {
       .tokenPassword("")
       .build();
     expect(cmd).toMatchInlineSnapshot(
-      `"marimo --yes edit path/to/file --host=localhost --port=2718 --headless --no-token"`,
+      `"marimo --yes edit path/to/file --host=localhost --port=2718 --headless --no-token --watch"`,
     );
   });
 
@@ -36,7 +36,7 @@ describe("MarimoCmdBuilder", () => {
       .tokenPassword("secret")
       .build();
     expect(cmd).toMatchInlineSnapshot(
-      `"marimo --yes -d edit path/to/file --host=localhost --port=2718 --headless --token-password=secret"`,
+      `"marimo --yes -d edit path/to/file --host=localhost --port=2718 --headless --token-password=secret --watch"`,
     );
   });
 
@@ -52,7 +52,7 @@ describe("MarimoCmdBuilder", () => {
       .tokenPassword("")
       .build();
     expect(cmd).toMatchInlineSnapshot(
-      `"marimo --yes run path/to/file --host=localhost --port=2718 --headless --no-token"`,
+      `"marimo --yes run path/to/file --host=localhost --port=2718 --headless --no-token --watch"`,
     );
   });
 
@@ -69,7 +69,7 @@ describe("MarimoCmdBuilder", () => {
       .build();
 
     expect(b).toMatchInlineSnapshot(
-      `"marimo --yes edit "path/to/some file" --host=localhost --port=2718 --headless --no-token"`,
+      `"marimo --yes edit "path/to/some file" --host=localhost --port=2718 --headless --no-token --watch"`,
     );
   });
 
@@ -86,7 +86,7 @@ describe("MarimoCmdBuilder", () => {
       .build();
 
     expect(b).toMatchInlineSnapshot(
-      `"marimo --yes edit path/to/file --host=0.0.0.0 --port=2718 --headless --no-token"`,
+      `"marimo --yes edit path/to/file --host=0.0.0.0 --port=2718 --headless --no-token --watch"`,
     );
   });
 
@@ -102,7 +102,39 @@ describe("MarimoCmdBuilder", () => {
       .sandbox(true)
       .build();
     expect(cmd).toMatchInlineSnapshot(
-      `"marimo --yes edit path/to/file --host=localhost --port=2718 --headless --no-token --sandbox"`,
+      `"marimo --yes edit path/to/file --host=localhost --port=2718 --headless --no-token --sandbox --watch"`,
+    );
+  });
+
+  it("should support watch mode", () => {
+    const cmd = new MarimoCmdBuilder()
+      .debug(false)
+      .mode("edit")
+      .fileOrDir("path/to/file")
+      .host("localhost")
+      .port(2718)
+      .headless(true)
+      .enableToken(false)
+      .watch(true)
+      .build();
+    expect(cmd).toMatchInlineSnapshot(
+      `"marimo --yes edit path/to/file --host=localhost --port=2718 --headless --no-token --watch"`,
+    );
+  });
+
+  it("should support disabling watch mode", () => {
+    const cmd = new MarimoCmdBuilder()
+      .debug(false)
+      .mode("edit")
+      .fileOrDir("path/to/file")
+      .host("localhost")
+      .port(2718)
+      .headless(true)
+      .enableToken(false)
+      .watch(false)
+      .build();
+    expect(cmd).toMatchInlineSnapshot(
+      `"marimo --yes edit path/to/file --host=localhost --port=2718 --headless --no-token"`,
     );
   });
 });

--- a/src/utils/cmd.ts
+++ b/src/utils/cmd.ts
@@ -64,6 +64,13 @@ export class MarimoCmdBuilder {
     return this;
   }
 
+  watch(value: boolean) {
+    if (value) {
+      this.cmd.push("--watch");
+    }
+    return this;
+  }
+
   build() {
     return this.cmd.join(" ");
   }


### PR DESCRIPTION
`--watch` seems very useful when using marimo within an editor so that edits within the editor (or automatic changes like symbol renames etc) are reflected in the notebook (vs today when those changes get silently overwritten by marimo)

Should not be merged before marimo support for `--watch` is released in marimo-team/marimo#3437 


Based on #57 

Note: in running tests locally, I'm seeing a bunch of failures in the export_as and convert tests (separate from these edits)