### PR TITLE
break: enforce r-strings for markdown cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This feature is experimental and may have some limitations. Some known limitatio
 - Notebooks can still be edited even though there may not be an active marimo server. This can be confusing since saving or running will not work.
 - For autocomplete to work when using native VSCode notebooks for many packages (including `marimo`, `numpy`, and more) you may be required to include a `pyproject.toml` file at the root of the workspace. marimo's editor gets around this by default but unfortunately, the VSCode's native notebook does not.
 - You cannot access **many** marimo features in the native notebook (and need to use the marimo browser), such as the variable explorer, dependency viewer, grid mode (plus other layouts), and more - so we show the notebook in "Kiosk Mode" which is a read-only view of the outputs and helper panels.
+- VSCode's native notebook does not support different string quoting styles (e.g. `r"""`, `"""`, `f"""`, etc.), so we default all markdown cells to use `r"""`.
 
 ## Python Configuration
 

--- a/src/notebook/__tests__/md.test.ts
+++ b/src/notebook/__tests__/md.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import { maybeMarkdown, toMarkdown } from "../md";
+
+describe("markdown utils", () => {
+  describe("toMarkdown", () => {
+    it("should wrap single line in mo.md()", () => {
+      expect(toMarkdown("hello")).toBe('mo.md(r"hello")');
+    });
+
+    it("should handle empty string", () => {
+      expect(toMarkdown("")).toBe('mo.md(r"")');
+    });
+
+    it("should handle whitespace", () => {
+      expect(toMarkdown("  hello  ")).toBe('mo.md(r"hello")');
+    });
+
+    it("should indent multiline content with 4 spaces", () => {
+      const input = `line 1
+line 2
+line 3`;
+      expect(toMarkdown(input)).toMatchInlineSnapshot(`
+        "mo.md(
+            r"""
+            line 1
+            line 2
+            line 3
+            """
+        )"
+      `);
+    });
+
+    it("should preserve existing indentation in multiline", () => {
+      const input = `line 1
+  line 2
+    line 3`;
+      expect(toMarkdown(input)).toMatchInlineSnapshot(`
+        "mo.md(
+            r"""
+            line 1
+              line 2
+                line 3
+            """
+        )"
+      `);
+    });
+    it("should handle multiline with empty lines", () => {
+      const input = `line 1
+
+line 2
+
+line 3`;
+      expect(trimEmptyLines(toMarkdown(input))).toMatchInlineSnapshot(`
+        "mo.md(
+            r"""
+            line 1
+
+            line 2
+
+            line 3
+            """
+        )"
+      `);
+    });
+
+    it("should handle multiline starting with empty line", () => {
+      const input = `
+line 1
+line 2`;
+      expect(toMarkdown(input)).toMatchInlineSnapshot(`
+        "mo.md(
+            r"""
+            line 1
+            line 2
+            """
+        )"
+      `);
+    });
+
+    it("should handle multiline ending with empty line", () => {
+      const input = `line 1
+line 2
+
+`;
+      expect(toMarkdown(input)).toMatchInlineSnapshot(`
+        "mo.md(
+            r"""
+            line 1
+            line 2
+            """
+        )"
+      `);
+    });
+  });
+
+  describe("maybeMarkdown", () => {
+    it("should extract content from mo.md() call", () => {
+      expect(maybeMarkdown('mo.md("hello")')).toBe("hello");
+    });
+
+    it("should handle empty mo.md()", () => {
+      expect(maybeMarkdown('mo.md("")')).toBe("");
+    });
+
+    it("should handle multiline mo.md()", () => {
+      const input = `mo.md("""
+    line 1
+    line 2
+    line 3
+""")`;
+      expect(maybeMarkdown(input)).toBe("line 1\nline 2\nline 3");
+    });
+
+    it("should handle raw strings", () => {
+      expect(maybeMarkdown('mo.md(r"hello")')).toBe("hello");
+    });
+
+    it("should handle triple quotes", () => {
+      expect(maybeMarkdown('mo.md("""hello""")')).toBe("hello");
+    });
+
+    it("should return null for invalid markdown", () => {
+      expect(maybeMarkdown("not markdown")).toBe(null);
+      expect(maybeMarkdown('mo.md("unclosed')).toBe(null);
+      expect(maybeMarkdown('mo.md(hello")')).toBe(null);
+      expect(maybeMarkdown('md("hello")')).toBe(null);
+    });
+
+    it("should dedent multiline content", () => {
+      const input = `mo.md("""
+    line 1
+      line 2
+        line 3
+""")`;
+      expect(maybeMarkdown(input)).toBe("line 1\n  line 2\n    line 3");
+    });
+
+    it("should handle mixed quotes", () => {
+      expect(maybeMarkdown(`mo.md('hello')`)).toBe("hello");
+      expect(maybeMarkdown(`mo.md("'hello'")`)).toBe("'hello'");
+    });
+
+    it("should handle whitespace", () => {
+      expect(maybeMarkdown('  mo.md("hello")  ')).toBe("hello");
+      expect(maybeMarkdown('mo.md(  "hello"  )')).toBe("hello");
+    });
+  });
+});
+
+function trimEmptyLines(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => (line.trim() ? line : ""))
+    .join("\n")
+    .trim();
+}

--- a/src/notebook/kernel.ts
+++ b/src/notebook/kernel.ts
@@ -24,9 +24,9 @@ import {
   type SkewToken,
   type UpdateCellIdsRequest,
 } from "./marimo/types";
-import { Strings } from "../utils/strings";
 import { maybeMarkdown, toMarkdown } from "./md";
 import { toArray } from "../utils/arrays";
+import { deepEqual } from "../utils/deepEqual";
 
 const DEFAULT_NAME = "__";
 

--- a/src/notebook/md.ts
+++ b/src/notebook/md.ts
@@ -1,0 +1,29 @@
+import { Strings } from "../utils/strings";
+
+export function toMarkdown(text: string): string {
+  // Trim
+  const value = text.trim();
+
+  const isMultiline = value.includes("\n");
+  if (!isMultiline) {
+    return `mo.md(r"${value}")`;
+  }
+
+  return `mo.md(\n${Strings.FOUR_SPACES}r"""\n${Strings.indent(value, Strings.FOUR_SPACES)}\n${Strings.FOUR_SPACES}"""\n)`;
+}
+
+export function maybeMarkdown(text: string): string | null {
+  // TODO: Python can safely extract the string value with the
+  // AST, anything done here is a bit of a hack, data should come from server.
+  const value = text.trim();
+  // Regular expression to match the function calls
+  const regex = /^mo\.md\(\s*r?((["'])(?:\2\2)?)(.*?)\1\s*\)$/gms; // 'g' flag to check all occurrences
+  const matches = [...value.matchAll(regex)];
+
+  // Check if there is exactly one match
+  if (matches.length === 1) {
+    const extractedString = matches[0][3]; // Extract the string content
+    return Strings.dedent(extractedString).trim();
+  }
+  return null;
+}

--- a/src/utils/__tests__/deepEqual.test.ts
+++ b/src/utils/__tests__/deepEqual.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { deepEqual } from "../deepEqual";
+
+describe("deepEqual", () => {
+  it("returns true for identical primitives", () => {
+    expect(deepEqual(1, 1)).toBe(true);
+    expect(deepEqual("test", "test")).toBe(true);
+    expect(deepEqual(true, true)).toBe(true);
+    expect(deepEqual(null, null)).toBe(true);
+    expect(deepEqual(undefined, undefined)).toBe(true);
+  });
+
+  it("returns false for different primitives", () => {
+    expect(deepEqual(1, 2)).toBe(false);
+    expect(deepEqual("test", "other")).toBe(false);
+    expect(deepEqual(true, false)).toBe(false);
+    expect(deepEqual(null, undefined)).toBe(false);
+  });
+
+  it("compares objects deeply", () => {
+    expect(deepEqual({ a: 1, b: 2 }, { a: 1, b: 2 })).toBe(true);
+    expect(deepEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
+    expect(deepEqual({ a: { b: 1 } }, { a: { b: 1 } })).toBe(true);
+    expect(deepEqual({ a: 1 }, { a: 2 })).toBe(false);
+    expect(deepEqual({ a: 1 }, { b: 1 })).toBe(false);
+  });
+
+  it("compares arrays deeply", () => {
+    expect(deepEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+    expect(deepEqual([{ a: 1 }], [{ a: 1 }])).toBe(true);
+    expect(deepEqual([1, 2], [1, 3])).toBe(false);
+    expect(deepEqual([1, 2], [1, 2, 3])).toBe(false);
+  });
+});

--- a/src/utils/__tests__/exec.test.ts
+++ b/src/utils/__tests__/exec.test.ts
@@ -5,8 +5,8 @@ vi.mock("@vscode/python-extension", () => ({}));
 
 import * as child_process from "node:child_process";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { execPython, hasPythonModule } from "../exec";
 import { workspace } from "vscode";
+import { execPython, hasPythonModule } from "../exec";
 
 vi.mock("node:child_process", () => ({
   execSync: vi.fn(),

--- a/src/utils/__tests__/strings.test.ts
+++ b/src/utils/__tests__/strings.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { Strings } from "../strings";
+
+describe("Strings", () => {
+  describe("indent", () => {
+    it("should indent each line with given string", () => {
+      const input = "line1\nline2\nline3";
+      const expected = "  line1\n  line2\n  line3";
+      expect(Strings.indent(input, "  ")).toBe(expected);
+    });
+
+    it("should handle empty string", () => {
+      expect(Strings.indent("", "  ")).toBe("");
+    });
+  });
+
+  describe("dedent", () => {
+    it("should remove common leading whitespace", () => {
+      const input = "    line1\n    line2\n    line3";
+      const expected = "line1\nline2\nline3";
+      expect(Strings.dedent(input)).toBe(expected);
+    });
+
+    it("should handle mixed indentation", () => {
+      const input = "    line1\n  line2\n      line3";
+      const expected = "  line1\nline2\n    line3";
+      expect(Strings.dedent(input)).toBe(expected);
+    });
+
+    it("should handle empty string", () => {
+      expect(Strings.dedent("")).toBe("");
+    });
+  });
+
+  it("should have FOUR_SPACES constant", () => {
+    expect(Strings.FOUR_SPACES).toBe("    ");
+  });
+});

--- a/src/utils/arrays.ts
+++ b/src/utils/arrays.ts
@@ -1,0 +1,9 @@
+export function toArray<T>(value: T | ReadonlyArray<T>): T[] {
+  if (Array.isArray(value)) {
+    return [...value];
+  }
+  if (value == null) {
+    return [];
+  }
+  return [value] as T[];
+}

--- a/src/utils/deepEqual.ts
+++ b/src/utils/deepEqual.ts
@@ -1,0 +1,21 @@
+// biome-ignore lint/suspicious/noExplicitAny: any is ok
+export function deepEqual(a: any, b: any): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (typeof a !== "object" || typeof b !== "object") {
+    return false;
+  }
+  if (Object.keys(a).length !== Object.keys(b).length) {
+    return false;
+  }
+  for (const key in a) {
+    if (!(key in b)) {
+      return false;
+    }
+    if (!deepEqual(a[key], b[key])) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -1,0 +1,21 @@
+export const Strings = {
+  indent: (str: string, indent: string) => {
+    if (str.length === 0) {
+      return str;
+    }
+    return str
+      .split("\n")
+      .map((line) => `${indent}${line}`)
+      .join("\n");
+  },
+  FOUR_SPACES: "    ",
+  dedent: (str: string) => {
+    const match = str.match(/^[ \t]*(?=\S)/gm);
+    if (!match) {
+      return str; // If no indentation, return original string
+    }
+    const minIndent = Math.min(...match.map((el) => el.length));
+    const re = new RegExp(`^[ \t]{${minIndent}}`, "gm");
+    return str.replace(re, "");
+  },
+};


### PR DESCRIPTION
Fixes #69

This fixes formatting of markdown cells. 

Also this breaks how markdown cells are sent back to marimo. Instead of `md.md("<markdown">)`, we wrap the markdown in an r-string `md.md("<markdown">)`. This how we do it in the marimo editor today, so matching this helps with consistency. 