### PR TITLE
fix: marimoPath usage, more integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,9 @@ jobs:
           cache: pnpm
 
       - name: 📥 Install dependencies
-        run: pnpm install
+        run: |
+          uv pip install marimo --system
+          pnpm install
 
       - name: 🧪 Run tests
         run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,13 +76,18 @@ jobs:
         with:
           version: 8
 
-      - name: ⎔ Setup uv
+      - name: 🐍 Setup uv
         uses: astral-sh/setup-uv@v5
+
+      - name: 🐍 Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
 
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: pnpm
 
       - name: 📥 Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+env:
+  MARIMO_SKIP_UPDATE_CHECK: true
+
 on:
   push:
     branches: [main]
@@ -58,3 +61,34 @@ jobs:
 
       - name: ʦ Typecheck
         run: pnpm typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.1
+
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v4
+
+      - name: ⎔ Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: ⎔ Setup uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: ⎔ Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: pnpm
+
+      - name: 📥 Install dependencies
+        run: pnpm install
+
+      - name: 🧪 Run tests
+        run: pnpm test
+
+

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To ensure marimo works correctly with your Python environment, you have several 
 > The extension will use the Python interpreter from the Python extension by default. Make sure you have the [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) installed and configured.
 
 1. **Workspace Settings (Recommended)**
-   Create or edit `.vscode/settings.json` in your workspace. You can set the default Python interpreter for your workspace, or just for marimo.
+   Create or edit `.vscode/settings.json` in your workspace. You can set the default Python interpreter for your entire workspace, or just for marimo.
 
    For setting the workspace Python interpreter, you can set:
 
@@ -60,7 +60,7 @@ To ensure marimo works correctly with your Python environment, you have several 
    }
    ```
 
-   For setting the marimo Python interpreter, you can set:
+   For setting the Python interpreter only for marimo, you can set:
 
    ```json
    {
@@ -83,8 +83,18 @@ To ensure marimo works correctly with your Python environment, you have several 
    - Install marimo: `pip install marimo`
    - VS Code should automatically detect the Python interpreter
 
-4. **uv and package environment sandboxes**
-   You can use `uvx` with `marimo edit --sandbox` to run marimo in a sandbox.
+4. **uv projects and package environment sandboxes**
+   If you are using `uv` to manage your Python project (e.g. with a `pyproject.toml` file). You can run `uv add marimo` to install marimo in your project's environment. Then update your settings to use:
+
+   ```json
+   {
+     "marimo.marimoPath": "uv run marimo",
+     "marimo.sandbox": true // optional
+   }
+   ```
+
+5. **uvx and package environment sandboxes**
+   If you are not creating Python projects and don't want to create virtual environments, you can use `uvx` with `marimo edit --sandbox` to run marimo in a sandbox.
 
    ```json
    {
@@ -106,7 +116,7 @@ To ensure marimo works correctly with your Python environment, you have several 
 - `marimo.showTerminal`: Open the terminal when the server starts (default: `false`)
 - `marimo.debug`: Enable debug logging (default: `false`)
 - `marimo.pythonPath`: Path to python interpreter (default: the one from python extension). Will be used with `/path/to/python -m marimo` to invoke marimo.
-- `marimo.marimoPath`: Path to marimo executable (default: `marimo`). This will override use of the `pythonPath` setting, and instead invoke commands like `/path/to/marimo edit` instead of `python -m marimo edit`.
+- `marimo.marimoPath`: Path to a marimo executable (default: None). This will override use of the `pythonPath` setting, and instead invoke commands like `/path/to/marimo edit` instead of `python -m marimo edit`.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -46,22 +46,36 @@ This feature is experimental and may have some limitations. Some known limitatio
 
 To ensure marimo works correctly with your Python environment, you have several options:
 
+> [!TIP]
+> The extension will use the Python interpreter from the Python extension by default. Make sure you have the [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) installed and configured.
+
 1. **Workspace Settings (Recommended)**
-   Create or edit `.vscode/settings.json` in your workspace:
+   Create or edit `.vscode/settings.json` in your workspace. You can set the default Python interpreter for your workspace, or just for marimo.
+
+   For setting the workspace Python interpreter, you can set:
 
    ```json
    {
-     "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
-     "marimo.marimoPath": "${workspaceFolder}/.venv/bin/marimo"
+     "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"
    }
    ```
+
+   For setting the marimo Python interpreter, you can set:
+
+   ```json
+   {
+     "marimo.pythonPath": "${workspaceFolder}/.venv/bin/python"
+   }
+   ```
+
+   If you set `marimo.pythonPath`, the extension will use that interpreter with `-m marimo` to invoke marimo.
 
 2. **Global Settings**
    You can also configure these settings globally in VS Code's settings:
 
    - Set `python.defaultInterpreterPath` to your preferred Python interpreter
-   - (Likely not needed) Set `marimo.marimoPath` to the path of your marimo installation
-   - Verify that marimo is available in your Python interpreter: `value/of/defaultInterpreterPath -m marimo`
+   - Verify that marimo is available in your Python interpreter: `/value/of/defaultInterpreterPath -m marimo`
+   - (Likely not needed) Set `marimo.marimoPath` to the path of your marimo installation. When set, the extension will use this path directly `/path/to/marimo` instead of `python -m marimo`.
 
 3. **Virtual Environments**
    If using a virtual environment:
@@ -74,18 +88,12 @@ To ensure marimo works correctly with your Python environment, you have several 
 
    ```json
    {
-     "marimo.pythonPath": "uv run python",
-     "marimo.marimoPath": "marimo",
+     "marimo.marimoPath": "uvx marimo",
      "marimo.sandbox": true
    }
    ```
 
-> [!TIP]
-> The extension will use the Python interpreter from the Python extension by default. Make sure you have the [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) installed and configured.
-
-## Extension Settings
-
-You can configure the extension using the following settings:
+## Configuration
 
 - `marimo.browserType`: Browser to open marimo app (`system` or `embedded`, default: `embedded`)
 - `marimo.port`: Default port for marimo server (default: `2818`)
@@ -97,8 +105,8 @@ You can configure the extension using the following settings:
 - `marimo.tokenPassword`: Token password (default: _empty_)
 - `marimo.showTerminal`: Open the terminal when the server starts (default: `false`)
 - `marimo.debug`: Enable debug logging (default: `false`)
-- `marimo.pythonPath`: Path to python interpreter (default: the one from python extension)
-- `marimo.marimoPath`: Path to marimo executable (default: `marimo`)
+- `marimo.pythonPath`: Path to python interpreter (default: the one from python extension). Will be used with `/path/to/python -m marimo` to invoke marimo.
+- `marimo.marimoPath`: Path to marimo executable (default: `marimo`). This will override use of the `pythonPath` setting, and instead invoke commands like `/path/to/marimo edit` instead of `python -m marimo edit`.
 
 ## Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -10,9 +10,15 @@
     "vscode": "^1.95.0"
   },
   "private": true,
-  "categories": ["Notebooks", "Machine Learning", "Data Science"],
+  "categories": [
+    "Notebooks",
+    "Machine Learning",
+    "Data Science"
+  ],
   "icon": "resources/marimo.png",
-  "activationEvents": ["onLanguage"],
+  "activationEvents": [
+    "onLanguage"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/marimo-team/vscode-marimo"
@@ -20,7 +26,11 @@
   "bugs": {
     "url": "https://github.com/marimo-team/vscode-marimo/issues"
   },
-  "files": ["dist", "resources", "LICENSE"],
+  "files": [
+    "dist",
+    "resources",
+    "LICENSE"
+  ],
   "main": "./dist/extension.js",
   "contributes": {
     "commands": [
@@ -317,7 +327,10 @@
       "properties": {
         "marimo.browserType": {
           "type": "string",
-          "enum": ["embedded", "system"],
+          "enum": [
+            "embedded",
+            "system"
+          ],
           "default": "embedded",
           "description": "The type of browser to use for opening marimo apps."
         },
@@ -385,7 +398,6 @@
     "lint": "biome check --apply .",
     "pack": "vsce package --no-dependencies",
     "codegen": "npx openapi-typescript https://raw.githubusercontent.com/marimo-team/marimo/0.8.22/openapi/api.yaml --immutable -o ./src/generated/api.ts",
-    "pretest": "pnpm run build && pnpm run lint",
     "publish": "vsce publish --no-dependencies",
     "publish:pre-release": "vsce publish --no-dependencies --pre-release",
     "openvsx:publish": "npx ovsx publish --pat",

--- a/src/__integration__/exec.test.ts
+++ b/src/__integration__/exec.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createVSCodeMock } from "../__mocks__/vscode";
+
+vi.mock("vscode", () => createVSCodeMock(vi));
+vi.mock("@vscode/python-extension", () => ({}));
+
+import { workspace } from "vscode";
+import { execMarimoCommand, execPythonModule } from "../utils/exec";
+
+beforeEach(() => {
+  workspace.getConfiguration().reset();
+});
+
+describe("execMarimoCommand integration tests", () => {
+  it("should work out of the box", async () => {
+    const output = await execMarimoCommand(["--version"]);
+    expect(output.toString()).toMatch(/\d+\.\d+\.\d+/);
+  });
+
+  it.each(["python", "uv run python"])(
+    "should run marimo --version with %s",
+    async (interpreter) => {
+      workspace.getConfiguration().set("marimo.pythonPath", interpreter);
+      const output = await execMarimoCommand(["--version"]);
+      expect(output.toString()).toMatch(/\d+\.\d+\.\d+/);
+    },
+  );
+
+  it.each(["uv run marimo", "uvx marimo", "uv tool run marimo"])(
+    "should run marimo --version with %s",
+    async (interpreter) => {
+      workspace.getConfiguration().set("marimo.marimoPath", interpreter);
+      const output = await execMarimoCommand(["--version"]);
+      expect(output.toString()).toMatch(/\d+\.\d+\.\d+/);
+    },
+  );
+
+  it("path path gets overridden by marimoPath", async () => {
+    workspace.getConfiguration().set("marimo.pythonPath", "doesnotexist");
+    expect(() => execMarimoCommand(["--version"])).rejects.toThrow(
+      /command not found/,
+    );
+
+    workspace.getConfiguration().set("marimo.marimoPath", "uv run marimo");
+    const output = await execMarimoCommand(["--version"]);
+    expect(output.toString()).toMatch(/\d+\.\d+\.\d+/);
+  });
+});
+
+describe("execPythonModule integration tests", () => {
+  it("should work out of the box", async () => {
+    const output = await execPythonModule(["marimo", "--version"]);
+    expect(output.toString()).toMatch(/\d+\.\d+\.\d+/);
+  });
+
+  it.each(["python", "uv run python"])(
+    "should run python -m marimo --version with %s",
+    async (interpreter) => {
+      workspace.getConfiguration().set("marimo.pythonPath", interpreter);
+      const output = await execPythonModule(["marimo", "--version"]);
+      expect(output.toString()).toMatch(/\d+\.\d+\.\d+/);
+    },
+  );
+});

--- a/src/__integration__/exec.test.ts
+++ b/src/__integration__/exec.test.ts
@@ -38,7 +38,7 @@ describe("execMarimoCommand integration tests", () => {
   it("path path gets overridden by marimoPath", async () => {
     workspace.getConfiguration().set("marimo.pythonPath", "doesnotexist");
     expect(() => execMarimoCommand(["--version"])).rejects.toThrow(
-      /command not found/,
+      /doesnotexist/,
     );
 
     workspace.getConfiguration().set("marimo.marimoPath", "uv run marimo");

--- a/src/__integration__/server-manager.test.ts
+++ b/src/__integration__/server-manager.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createVSCodeMock } from "../__mocks__/vscode";
+
+vi.mock("vscode", () => createVSCodeMock(vi));
+vi.mock("@vscode/python-extension", () => ({}));
+
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type ExtensionContext, type Memento, window, workspace } from "vscode";
+import type { Config } from "../config";
+import { setExtension } from "../ctx";
+import { ServerManager } from "../services/server-manager";
+import { sleep } from "../utils/async";
+
+describe("ServerManager integration tests", () => {
+  let config: Config;
+  let manager: ServerManager;
+
+  beforeEach(() => {
+    const tmpDir = tmpdir();
+    workspace.getConfiguration().reset();
+    config = {
+      root: join(tmpDir, "nb.py"),
+      browser: "system",
+      port: 2918,
+      readPort: 2919,
+      host: "localhost",
+      https: false,
+      enableToken: false,
+      tokenPassword: "",
+      debug: false,
+      sandbox: false,
+      watch: false,
+    } as Config;
+    manager = ServerManager.getInstance(config);
+    const globalState = new Map();
+    setExtension({
+      globalState: {
+        get: vi.fn().mockImplementation((key) => globalState.get(key)),
+        update: vi
+          .fn()
+          .mockImplementation((key, value) => globalState.set(key, value)),
+        keys: vi.fn().mockImplementation(() => Array.from(globalState.keys())),
+      } as unknown as Memento,
+    } as unknown as ExtensionContext);
+    manager.init();
+  });
+
+  afterEach(async () => {
+    await manager.stopServer();
+  });
+
+  it("should start and stop server", async () => {
+    expect(manager.getStatus()).toBe("stopped");
+
+    const result = await manager.start();
+    expect(result.port).toBeGreaterThan(0);
+    expect(result.skewToken).toBeDefined();
+    expect(result.version).toMatch(/\d+\.\d+\.\d+/);
+    expect(manager.getStatus()).toBe("started");
+
+    await manager.stopServer();
+    expect(manager.getStatus()).toBe("stopped");
+  });
+
+  it("should start and stop a server with custom python path", async () => {
+    workspace.getConfiguration().set("marimo.pythonPath", "uv run python");
+    const result = await manager.start();
+    expect(result.port).toBeGreaterThan(0);
+    expect(result.skewToken).toBeDefined();
+    expect(result.version).toMatch(/\d+\.\d+\.\d+/);
+    expect(manager.getStatus()).toBe("started");
+
+    await manager.stopServer();
+    expect(manager.getStatus()).toBe("stopped");
+  });
+
+  it("should start and stop a server with custom marimo path", async () => {
+    workspace.getConfiguration().set("marimo.marimoPath", "uv run marimo");
+    const result = await manager.start();
+    expect(result.port).toBeGreaterThan(0);
+    expect(result.skewToken).toBeDefined();
+    expect(result.version).toMatch(/\d+\.\d+\.\d+/);
+    expect(manager.getStatus()).toBe("started");
+
+    await manager.stopServer();
+    expect(manager.getStatus()).toBe("stopped");
+  });
+
+  it("should reuse existing server if healthy", async () => {
+    const firstStart = await manager.start();
+    const secondStart = await manager.start();
+
+    expect(secondStart.port).toBe(firstStart.port);
+    expect(secondStart.skewToken).toBe(firstStart.skewToken);
+
+    // Check if healthy
+    const isHealthy = await manager.isHealthy(firstStart.port);
+    expect(isHealthy).toBe(true);
+  });
+
+  it.skip("should restart unhealthy server", async () => {
+    const firstStart = await manager.start();
+
+    // Force server into unhealthy state by stopping it directly
+    await manager.stopServer();
+
+    // Should detect unhealthy state and restart
+    const secondStart = await manager.start();
+    expect(secondStart.port).not.toBe(firstStart.port);
+  });
+
+  it("should handle multiple start requests while starting", async () => {
+    const startPromise1 = manager.start();
+    const startPromise2 = manager.start();
+
+    const [result1, result2] = await Promise.all([
+      startPromise1,
+      startPromise2,
+    ]);
+    expect(result1.port).toBe(result2.port);
+  });
+
+  it("should get active sessions", async () => {
+    await manager.start();
+    const sessions = await manager.getActiveSessions();
+    expect(Array.isArray(sessions)).toBe(true);
+  });
+
+  it.skip("should show warning and handle restart on unhealthy server", async () => {
+    await manager.start();
+    const showWarningMock = vi.spyOn(window, "showWarningMessage");
+
+    // Simulate health check failure
+    vi.spyOn(global, "fetch").mockRejectedValueOnce(
+      new Error("Connection failed"),
+    );
+
+    // Trigger health check
+    await sleep(100);
+
+    expect(showWarningMock).toHaveBeenCalledWith(
+      "The marimo server is not responding. What would you like to do?",
+      "Restart Server",
+      "Ignore",
+    );
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,7 +16,7 @@ export interface Config {
   readonly port: number;
   readonly readPort: number;
   readonly host: string;
-  readonly marimoPath: string;
+  readonly marimoPath: string | undefined;
   readonly enableToken: boolean;
   readonly tokenPassword: string | undefined;
   readonly https: boolean;

--- a/src/config.ts
+++ b/src/config.ts
@@ -110,10 +110,15 @@ export const Config = {
 
   /**
    * The path to the marimo package to use.
-   * @default "marimo"
+   * @default undefined (use the default marimo package)
    */
-  get marimoPath() {
-    return getConfig("marimoPath", "marimo");
+  get marimoPath(): string | undefined {
+    const path: string | undefined = getConfig("marimoPath");
+    // Ignore just 'marimo'
+    if (path === "marimo") {
+      return undefined;
+    }
+    return path;
   },
 
   // UI settings

--- a/src/convert/convert.ts
+++ b/src/convert/convert.ts
@@ -1,10 +1,9 @@
 import path from "node:path";
 import { Uri, window, workspace } from "vscode";
-import { Config } from "../config";
 import { getUniqueFilename } from "../export/export-as";
 import { logger } from "../logger";
 import { printError } from "../utils/errors";
-import { execPython } from "../utils/exec";
+import { execMarimoCommand } from "../utils/exec";
 
 export async function convertIPyNotebook(filePath: string) {
   return convertNotebook(filePath, "ipynb");
@@ -22,8 +21,7 @@ async function convertNotebook(
     // convert
     const directory = path.dirname(filePath);
     // Execute marimo via python
-    const response = await execPython([
-      Config.marimoPath,
+    const response = await execMarimoCommand([
       "convert",
       `'${filePath}'`, // Wrap in single quotes to handle spaces in path
     ]);

--- a/src/export/export-as.ts
+++ b/src/export/export-as.ts
@@ -1,10 +1,9 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { Uri, ViewColumn, window, workspace } from "vscode";
-import { Config } from "../config";
 import { logger } from "../logger";
 import { printError } from "../utils/errors";
-import { execPython, hasPythonModule } from "../utils/exec";
+import { execMarimoCommand, hasPythonModule } from "../utils/exec";
 
 export type ExportType =
   | "ipynb"
@@ -62,8 +61,7 @@ export async function exportNotebookAs(
 
     // Run export via marimo CLI
     const directory = path.dirname(filePath);
-    const response = await execPython([
-      Config.marimoPath,
+    const response = await execMarimoCommand([
       "export",
       getExportCommand(exportType),
       `'${filePath}'`, // Wrap in single quotes to handle spaces in path

--- a/src/launcher/controller.ts
+++ b/src/launcher/controller.ts
@@ -16,7 +16,7 @@ import { logger } from "../logger";
 import type { ServerManager } from "../services/server-manager";
 import { StatusBar } from "../ui/status-bar";
 import { MarimoCmdBuilder } from "../utils/cmd";
-import { getInterpreter } from "../utils/exec";
+import { getInterpreter, maybeQuotes } from "../utils/exec";
 import { ping } from "../utils/network";
 import { getFocusedMarimoTextEditor } from "../utils/query";
 import { asURL } from "../utils/url";
@@ -101,10 +101,18 @@ export class MarimoController implements Disposable {
       .build();
 
     const interpreter = await getInterpreter();
-    if (interpreter) {
+    if (Config.marimoPath) {
+      logger.info(`Using marimo path ${Config.marimoPath}`);
+      await this.terminal.executeCommand(
+        `${maybeQuotes(Config.marimoPath)} ${cmd}`,
+      );
+    } else if (interpreter) {
       logger.info(`Using interpreter ${interpreter}`);
-      await this.terminal.executeCommand(`${interpreter} -m ${cmd}`);
+      await this.terminal.executeCommand(
+        `${maybeQuotes(interpreter)} -m marimo ${cmd}`,
+      );
     } else {
+      logger.info("Using default interpreter");
       await this.terminal.executeCommand(cmd);
     }
 

--- a/src/launcher/terminal.ts
+++ b/src/launcher/terminal.ts
@@ -104,13 +104,17 @@ export class MarimoTerminal implements IMarimoTerminal {
   @LogMethodCalls()
   async executeCommand(cmd: string) {
     await this.ensureTerminal();
-    this.terminal?.sendText(cmd);
+    if (!this.terminal) {
+      this.logger.error("terminal not found");
+      return;
+    }
+    this.terminal.sendText(cmd);
 
     if (Config.showTerminal) {
-      this.terminal?.show(false);
+      this.terminal.show(false);
     }
     await wait(2000);
-    const pid = await this.terminal?.processId;
+    const pid = await this.terminal.processId;
     if (pid) {
       getGlobalState().update(this.keyFor("pid"), pid);
     }

--- a/src/notebook/kernel.ts
+++ b/src/notebook/kernel.ts
@@ -3,6 +3,8 @@ import { MarimoPanelManager } from "../browser/panel";
 import { Config, composeUrl } from "../config";
 import { logger as l, logger } from "../logger";
 import type { ILifecycle } from "../types";
+import { toArray } from "../utils/arrays";
+import { deepEqual } from "../utils/deepEqual";
 import { Deferred } from "../utils/deferred";
 import { invariant } from "../utils/invariant";
 import { LogMethodCalls } from "../utils/log";
@@ -25,8 +27,6 @@ import {
   type UpdateCellIdsRequest,
 } from "./marimo/types";
 import { maybeMarkdown, toMarkdown } from "./md";
-import { toArray } from "../utils/arrays";
-import { deepEqual } from "../utils/deepEqual";
 
 const DEFAULT_NAME = "__";
 

--- a/src/utils/__tests__/cmd.test.ts
+++ b/src/utils/__tests__/cmd.test.ts
@@ -20,7 +20,7 @@ describe("MarimoCmdBuilder", () => {
       .tokenPassword("")
       .build();
     expect(cmd).toMatchInlineSnapshot(
-      `"marimo --yes edit path/to/file --host=localhost --port=2718 --headless --no-token"`,
+      `"--yes edit path/to/file --host=localhost --port=2718 --headless --no-token"`,
     );
   });
 
@@ -36,7 +36,7 @@ describe("MarimoCmdBuilder", () => {
       .tokenPassword("secret")
       .build();
     expect(cmd).toMatchInlineSnapshot(
-      `"marimo --yes -d edit path/to/file --host=localhost --port=2718 --headless --token-password=secret"`,
+      `"--yes -d edit path/to/file --host=localhost --port=2718 --headless --token-password=secret"`,
     );
   });
 
@@ -52,7 +52,7 @@ describe("MarimoCmdBuilder", () => {
       .tokenPassword("")
       .build();
     expect(cmd).toMatchInlineSnapshot(
-      `"marimo --yes run path/to/file --host=localhost --port=2718 --headless --no-token"`,
+      `"--yes run path/to/file --host=localhost --port=2718 --headless --no-token"`,
     );
   });
 
@@ -69,7 +69,7 @@ describe("MarimoCmdBuilder", () => {
       .build();
 
     expect(b).toMatchInlineSnapshot(
-      `"marimo --yes edit "path/to/some file" --host=localhost --port=2718 --headless --no-token"`,
+      `"--yes edit "path/to/some file" --host=localhost --port=2718 --headless --no-token"`,
     );
   });
 
@@ -86,7 +86,7 @@ describe("MarimoCmdBuilder", () => {
       .build();
 
     expect(b).toMatchInlineSnapshot(
-      `"marimo --yes edit path/to/file --host=0.0.0.0 --port=2718 --headless --no-token"`,
+      `"--yes edit path/to/file --host=0.0.0.0 --port=2718 --headless --no-token"`,
     );
   });
 
@@ -102,7 +102,7 @@ describe("MarimoCmdBuilder", () => {
       .sandbox(true)
       .build();
     expect(cmd).toMatchInlineSnapshot(
-      `"marimo --yes edit path/to/file --host=localhost --port=2718 --headless --no-token --sandbox"`,
+      `"--yes edit path/to/file --host=localhost --port=2718 --headless --no-token --sandbox"`,
     );
   });
 
@@ -118,7 +118,7 @@ describe("MarimoCmdBuilder", () => {
       .watch(true)
       .build();
     expect(cmd).toMatchInlineSnapshot(
-      `"marimo --yes edit path/to/file --host=localhost --port=2718 --headless --no-token --watch"`,
+      `"--yes edit path/to/file --host=localhost --port=2718 --headless --no-token --watch"`,
     );
   });
 });

--- a/src/utils/__tests__/config.test.ts
+++ b/src/utils/__tests__/config.test.ts
@@ -60,6 +60,10 @@ describe("Config", () => {
 
     mockGet.mockReturnValueOnce("custom-marimo");
     expect(Config.marimoPath).toBe("custom-marimo");
+    mockGet.mockReturnValueOnce("uvx run marimo");
+    expect(Config.marimoPath).toBe("uvx run marimo");
+    mockGet.mockReturnValueOnce("marimo");
+    expect(Config.marimoPath).toBe(undefined);
 
     mockGet.mockReturnValueOnce(true);
     expect(Config.showTerminal).toBe(true);

--- a/src/utils/__tests__/deepEqual.test.ts
+++ b/src/utils/__tests__/deepEqual.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { deepEqual } from "../deepEqual";
 
 describe("deepEqual", () => {

--- a/src/utils/__tests__/exec.test.ts
+++ b/src/utils/__tests__/exec.test.ts
@@ -6,7 +6,7 @@ vi.mock("@vscode/python-extension", () => ({}));
 import * as child_process from "node:child_process";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { workspace } from "vscode";
-import { execPython, hasPythonModule } from "../exec";
+import { execMarimoCommand, execPythonModule, hasPythonModule } from "../exec";
 
 vi.mock("node:child_process", () => ({
   execSync: vi.fn(),
@@ -17,38 +17,71 @@ beforeEach(() => {
 });
 
 describe("exec utilities", () => {
-  it("should handle regular python path", async () => {
-    workspace.getConfiguration().set("marimo.pythonPath", "python");
+  describe("execMarimoCommand", () => {
+    it("should use marimoPath when set", async () => {
+      workspace.getConfiguration().set("marimo.marimoPath", "/path/to/marimo");
+      await execMarimoCommand(["edit", "--version"]);
+      expect(child_process.execSync).toHaveBeenCalledWith(
+        "/path/to/marimo edit --version",
+      );
+    });
 
-    await execPython(["marimo", "--version"]);
-    expect(child_process.execSync).toHaveBeenCalledWith(
-      "python -m marimo --version",
-    );
+    it("should fallback to python -m marimo when marimoPath is default", async () => {
+      workspace.getConfiguration().set("marimo.marimoPath", "marimo");
+      workspace.getConfiguration().set("marimo.pythonPath", "python");
+      await execMarimoCommand(["edit", "--version"]);
+      expect(child_process.execSync).toHaveBeenCalledWith(
+        "python -m marimo edit --version",
+      );
+    });
+
+    it("should handle spaces in marimoPath", async () => {
+      workspace
+        .getConfiguration()
+        .set("marimo.marimoPath", "/path with spaces/marimo");
+      await execMarimoCommand(["edit", "--version"]);
+      expect(child_process.execSync).toHaveBeenCalledWith(
+        '"/path with spaces/marimo" edit --version',
+      );
+    });
   });
 
-  it("should quote python path with spaces", async () => {
-    workspace
-      .getConfiguration()
-      .set("marimo.pythonPath", "/path with spaces/python");
-    await execPython(["marimo", "--version"]);
-    expect(child_process.execSync).toHaveBeenCalledWith(
-      '"/path with spaces/python" -m marimo --version',
-    );
+  describe("execPythonModule", () => {
+    it("should handle regular python path", async () => {
+      workspace.getConfiguration().set("marimo.pythonPath", "python");
+
+      await execPythonModule(["marimo", "--version"]);
+      expect(child_process.execSync).toHaveBeenCalledWith(
+        "python -m marimo --version",
+      );
+    });
+
+    it("should quote python path with spaces", async () => {
+      workspace
+        .getConfiguration()
+        .set("marimo.pythonPath", "/path with spaces/python");
+      await execPythonModule(["marimo", "--version"]);
+      expect(child_process.execSync).toHaveBeenCalledWith(
+        '"/path with spaces/python" -m marimo --version',
+      );
+    });
+
+    it("should not quote uv run python", async () => {
+      workspace.getConfiguration().set("marimo.pythonPath", "uv run python");
+      await execPythonModule(["marimo", "--version"]);
+      expect(child_process.execSync).toHaveBeenCalledWith(
+        "uv run python -m marimo --version",
+      );
+    });
   });
 
-  it("should not quote uv run python", async () => {
-    workspace.getConfiguration().set("marimo.pythonPath", "uv run python");
-    await execPython(["marimo", "--version"]);
-    expect(child_process.execSync).toHaveBeenCalledWith(
-      "uv run python -m marimo --version",
-    );
-  });
-
-  it("should handle hasPythonModule with uv run python", async () => {
-    workspace.getConfiguration().set("marimo.pythonPath", "uv run python");
-    await hasPythonModule("marimo");
-    expect(child_process.execSync).toHaveBeenCalledWith(
-      "uv run python -c 'import marimo'",
-    );
+  describe("hasPythonModule", () => {
+    it("should handle hasPythonModule with uv run python", async () => {
+      workspace.getConfiguration().set("marimo.pythonPath", "uv run python");
+      await hasPythonModule("marimo");
+      expect(child_process.execSync).toHaveBeenCalledWith(
+        "uv run python -c 'import marimo'",
+      );
+    });
   });
 });

--- a/src/utils/async.ts
+++ b/src/utils/async.ts
@@ -1,0 +1,3 @@
+export const sleep = (ms: number) => {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+};

--- a/src/utils/cmd.ts
+++ b/src/utils/cmd.ts
@@ -1,5 +1,5 @@
 export class MarimoCmdBuilder {
-  private cmd: string[] = ["marimo", "--yes"];
+  private cmd: string[] = ["--yes"];
 
   debug(value: boolean) {
     if (value) {


### PR DESCRIPTION
Fixes: https://github.com/marimo-team/vscode-marimo/issues/70

This fixes the usage of `marimoPath` config. 

1. If `marimoPath` is given, we use that as the executable. This overrides `pythonPath`.
2. If `pythonPath` is given, we use that to invoke the marimo module `-m marimo`.
3. Otherwise we fallback to the default python interpreter 