### PR TITLE
chore: bump node-version to 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 18
+          node-version: 24
           cache: pnpm
 
       - name: 📥 Install dependencies
@@ -46,7 +46,7 @@ jobs:
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 18
+          node-version: 24
           cache: pnpm
 
       - name: 📥 Install dependencies
@@ -78,7 +78,7 @@ jobs:
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: 📥 Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 22.15.0
+          node-version: 24
 
       - run: npx changelogithub
         env:


### PR DESCRIPTION
Aligns CI Node version with other marimo-team repos (Node 24). Bumps ci.yml from 18/20 and release.yml from 22.15.0.