### PR TITLE
ci: add autofix.ci

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,39 @@
+name: autofix.ci # needed to securely identify the workflow
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: ⎔ Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - name: ⎔ Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: 📥 Install dependencies
+        run: pnpm install
+
+      # `pnpm lint` runs `biome check --write .`, applying formatting/lint fixes.
+      # Unfixable lint errors are CI's job to report; don't let them block
+      # uploading the fixes that did apply.
+      - run: pnpm lint || true
+
+      - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4

--- a/src/utils/__tests__/exec.test.ts
+++ b/src/utils/__tests__/exec.test.ts
@@ -25,7 +25,7 @@ beforeEach(() => {
 describe("exec utilities", () => {
   const env = expect.objectContaining({
     MARIMO_DANGEROUS_SANDBOX: "1",
-  })
+  });
   describe("execMarimoCommand", () => {
     it("should use marimoPath when set", async () => {
       workspace.getConfiguration().set("marimo.marimoPath", "/path/to/marimo");


### PR DESCRIPTION
## What this does

Adds an `autofix.ci` workflow that runs the repo's fixer on every push to `main` and on pull requests, then uses the [autofix.ci](https://autofix.ci) app to push the resulting formatting/lint fixes back onto the PR branch.

- Workflow `name` is exactly `autofix.ci` — the service identifies the workflow by name for security.
- Fixer command: `pnpm lint` (which runs `biome check --write .`), wrapped in `|| true` so unfixable lint findings (CI's job to report) never block uploading the fixes that did apply.
- Setup + install steps mirror this repo's own `ci.yml` (pnpm/action-setup, setup-node 24, `pnpm install`). Everything is SHA-pinned with matching `# vX` comments.
- `autofix-ci/action` runs last.

The **autofix.ci GitHub App is installed org-wide** for marimo-team (confirmed by an org admin), so no per-repo app configuration is needed.

## Included fix

Running the fixer against the current tree produced one mechanical Biome formatting fix, included here:
- `src/utils/__tests__/exec.test.ts` — missing semicolon.

## Verification

Cloned, `pnpm install --frozen-lockfile`, ran `pnpm lint`: Biome fixed 1 file (the change above) and reported 11 pre-existing `noExplicitAny` warnings (unfixable — left for CI). Workflow validated with `actionlint` (clean).

Part of the marimo-team engineering-excellence initiative to standardize autofix across repos.

Do not auto-merge.