### PR TITLE
docs: add AGENTS.md with CLAUDE.md symlink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# vscode-marimo
+
+VS Code extension to run marimo notebooks, published to the Marketplace as `marimo-team.marimo`.
+
+## Development
+
+```bash
+pnpm install
+pnpm test        # vitest
+pnpm lint        # biome check --write . (autofix.ci runs this on PRs)
+pnpm typecheck   # tsc --noEmit
+pnpm build       # tsup -> dist/extension.js
+pnpm pack        # vsce package --no-dependencies -> .vsix
+```
+
+- Repo is deprecated; active development moved to [marimo-lsp](https://github.com/marimo-team/marimo-lsp).
+- `pnpm test` includes integration tests under `src/__integration__/` that launch a real marimo server — they need `marimo` on PATH and fail without it.
+- Packaging/publishing use `vsce` (`pnpm pack` / `pnpm publish` / `pnpm release`), not npm.
+- CI is `workflow_dispatch`-only; run the commands above locally.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
This adds an `AGENTS.md` as the canonical agent-context doc, with `CLAUDE.md` as a symlink to it (`ln -s AGENTS.md CLAUDE.md`) so both Claude and other coding agents read the same file. Part of the marimo-team engineering-excellence initiative to standardize agent docs across repos. The content is deliberately minimal — a one-line overview plus verified development commands — because these files load into every agent context, so fewer tokens is better.